### PR TITLE
Add timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         uses: ./
         id: python-test
         with:
+          timeout: 10
           max-score: 100
       - name: Decode and assert python-test
         uses: actions/github-script@v6

--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,5 @@ runs:
   image: Dockerfile
   entrypoint: "/opt/test-runner/bin/run.sh"
   args:
+    - ${{ inputs.timeout }}
     - ${{ inputs.max-score }}

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: "GitHub Classroom Python Grader"
 author: "GitHub"
 description: "A plugin for GitHub Classroom's Autograder using pytest to ensure student executables output the correct values on tests."
 inputs:
+  timeout:
+    description: "Duration (in minutes) before the test is terminated. Defaults to 10 minutes with a maximum limit of 60 minutes."
+    default: "10"
+    required: true
   max-score:
     description: "The maximum amount of points a student can receive for this test."
     required: false

--- a/bin/run.py
+++ b/bin/run.py
@@ -43,10 +43,18 @@ def main():
         help="max amount of points the test suite is worth",
     )
 
+    parser.add_argument(
+        "timeout",
+        metavar="time",
+        type=int,
+        help="max amount of time the test can run before before terminating",
+    )
+
     parser.add_argument("pytest_args", nargs=REMAINDER)
 
     args = parser.parse_args()
-    runner.run(args.input, args.output, args.max_score, args.pytest_args)
+
+    runner.run(args.input, args.output, args.max_score, args.timeout*60, args.pytest_args)
 
 if __name__ == "__main__":
     main()

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,8 +5,9 @@ export PYTHONPATH="$root:$PYTHONPATH"
 
 mkdir autograding_output
 
-MAX_SCORE="${1:-0}"
+TIMEOUT="$1"
+MAX_SCORE="${2:-0}"
 
-python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE"
+python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE" "$TIMEOUT"
 
 echo "result=$(jq -c . autograding_output/results.json | jq -sRr @base64)" >> "$GITHUB_OUTPUT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ black<=22.3.0
 pytest~=7.2.2
 pytest-subtests~=0.11.0
 tomli>=1.1.0; python_full_version < '3.11.2'
+timeout-decorator~=0.5.0

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -8,6 +8,8 @@ from typing import List
 from pathlib import Path
 import json
 import shutil
+import time
+import timeout_decorator
 
 import pytest
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -8,14 +8,12 @@ from typing import List
 from pathlib import Path
 import json
 import shutil
-import time
-import timeout_decorator
 
 import pytest
+import timeout_decorator
 
 from .data import Directory, Hierarchy, Results, Test
 from .sort import TestOrder
-from time import timeout, TimeoutError
 
 
 
@@ -215,7 +213,7 @@ def run(indir: Directory, outdir: Directory, max_score: int, timeout_duration: i
     reporter = ResultsReporter()
     reporter.results.max_score = max_score
     try:
-        @timeout(timeout_duration)
+        @timeout_decorator(timeout_duration)
         def run_tests():
             pytest.main(_sanitize_args(args or []) + [str(tf) for tf in test_files], plugins=[reporter])
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -213,7 +213,7 @@ def run(indir: Directory, outdir: Directory, max_score: int, timeout_duration: i
     reporter = ResultsReporter()
     reporter.results.max_score = max_score
     try:
-        @timeout_decorator.timeout_decorator(timeout_duration)
+        @timeout_decorator.timeout(timeout_duration)
         def run_tests():
             pytest.main(_sanitize_args(args or []) + [str(tf) for tf in test_files], plugins=[reporter])
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -10,8 +10,7 @@ import json
 import shutil
 
 import pytest
-import timeout_decorator
-
+from timeout_decorator import timeout_decorator
 from .data import Directory, Hierarchy, Results, Test
 from .sort import TestOrder
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -10,7 +10,8 @@ import json
 import shutil
 
 import pytest
-from timeout_decorator import timeout_decorator
+import timeout_decorator
+
 from .data import Directory, Hierarchy, Results, Test
 from .sort import TestOrder
 
@@ -212,7 +213,7 @@ def run(indir: Directory, outdir: Directory, max_score: int, timeout_duration: i
     reporter = ResultsReporter()
     reporter.results.max_score = max_score
     try:
-        @timeout_decorator(timeout_duration)
+        @timeout_decorator.timeout_decorator(timeout_duration)
         def run_tests():
             pytest.main(_sanitize_args(args or []) + [str(tf) for tf in test_files], plugins=[reporter])
 


### PR DESCRIPTION
This pull request implements a timeout inside the runner. The changes allow users to specify a timeout duration for tests, which will terminate the test if it exceeds the given time limit. The relevant block of code is here: https://github.com/education/autograding-python-grader/pull/7/files#diff-ae373fccc1613cb3a222d33ff51e892d58bcdff7173a9e87e80d0d1313b7ac8eR215-R222
