### PR TITLE
Pass in named params

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|
 | `timeout`       | Duration (in minutes) before the test is terminated. Defaults to 10 minutes with a maximum limit of 6 hours.    | Yes      |
 | `max-score`     | Points to be awarded if the test passes.                                                                        | No       |
+| `setup-command`         | Command to execute prior to the test, typically for environment setup or dependency installation.                                                                | No       |
 
 ### Outputs
 
@@ -45,6 +46,7 @@ jobs:
       with:
         timeout: '15'
         max-score: '100'
+        setup-command: 'pip install -r requirements.txt'
     - name: Autograding Reporter
       uses: ...
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ runs:
   image: Dockerfile
   entrypoint: "/opt/test-runner/bin/run.sh"
   args:
-    - "--timeout ${{ inputs.timeout }}"
-    - "--max-score ${{ inputs.max-score }}"
-    - "--setup-command${{ inputs.setup-command }}"
+    - "--timeout=${{ inputs.timeout }}"
+    - "--max-score=${{ inputs.max-score }}"
+    - "--setup-command=${{ inputs.setup-command }}"

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,6 @@ runs:
   image: Dockerfile
   entrypoint: "/opt/test-runner/bin/run.sh"
   args:
-    - ${{ inputs.timeout }}
-    - ${{ inputs.max-score }}
-    - ${{ inputs.setup-command }}
+    - "--timeout ${{ inputs.timeout }}"
+    - "--max-score ${{ inputs.max-score }}"
+    - "--setup-command${{ inputs.setup-command }}"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -26,7 +26,11 @@ done
 
 echo "TIMEOUT is $TIMEOUT"
 echo "MAX_SCORE is $MAX_SCORE"
-echo "SETUP_COMMAND is $SETUP_COMMAND"
+
+if [ -n "$SETUP_COMMAND" ]; then
+  echo "Running setup command: $SETUP_COMMAND"
+  eval "$SETUP_COMMAND"
+fi
 
 python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE" "$TIMEOUT"
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,13 +5,29 @@ export PYTHONPATH="$root:$PYTHONPATH"
 
 mkdir autograding_output
 
-TIMEOUT="$1"
-MAX_SCORE="${2:-0}"
-SETUP_COMMAND="$3"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --timeout=*)
+      TIMEOUT="${1#*=}"
+      ;;
+    --max_score=*)
+      MAX_SCORE="${1#*=}"
+      ;;
+    --setup_command=*)
+      SETUP_COMMAND="${1#*=}"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
 
-if [ -n "$SETUP_COMMAND" ]; then
-  $SETUP_COMMAND
-fi
+echo "TIMEOUT is $TIMEOUT"
+echo "MAX_SCORE is $MAX_SCORE"
+echo "SETUP_COMMAND is $SETUP_COMMAND"
 
 python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE" "$TIMEOUT"
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -20,7 +20,6 @@ while [ $# -gt 0 ]; do
       printf "***************************\n"
       printf "* Warning: Unknown argument.*\n"
       printf "***************************\n"
-      exit 1
   esac
   shift
 done

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -12,6 +12,7 @@ while [ $# -gt 0 ]; do
       ;;
     --max-score=*)
       MAX_SCORE="${1#*=}"
+      MAX_SCORE="${MAX_SCORE:-0}"
       ;;
     --setup-command=*)
       SETUP_COMMAND="${1#*=}"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -18,7 +18,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       printf "***************************\n"
-      printf "* Error: Invalid argument.*\n"
+      printf "* Warning: Unknown argument.*\n"
       printf "***************************\n"
       exit 1
   esac

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -10,10 +10,10 @@ while [ $# -gt 0 ]; do
     --timeout=*)
       TIMEOUT="${1#*=}"
       ;;
-    --max_score=*)
+    --max-score=*)
       MAX_SCORE="${1#*=}"
       ;;
-    --setup_command=*)
+    --setup-command=*)
       SETUP_COMMAND="${1#*=}"
       ;;
     *)


### PR DESCRIPTION
The most important change is:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L23-R25): Modified the `args:` section under `runs:` to include the variable names `timeout`, `max-score`, and `setup-command` along with their values. This provides more clarity on the purpose of each argument.

Also added some param parsing logic in `run.sh` so the file can determine which param corresponds to which since max-score and setup-command are not required. 

Rendered [README.md](https://github.com/education/autograding-python-grader/blob/8c1a08e60ee672b43917d50011755d818abaf24f/README.md)