### PR TITLE
Place timeout in `run.sh` instead of Python execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install -r /requirements.txt
 RUN apt-get update \
  && apt-get install jq -y \
  && apt-get autoremove -y \
+ && apt-get install coreutils -y \
  && rm -rf /var/lib/apt/lists/*
 
 COPY . /opt/test-runner

--- a/bin/run.py
+++ b/bin/run.py
@@ -43,18 +43,11 @@ def main():
         help="max amount of points the test suite is worth",
     )
 
-    parser.add_argument(
-        "timeout",
-        metavar="time",
-        type=int,
-        help="max amount of time the test can run before before terminating",
-    )
-
     parser.add_argument("pytest_args", nargs=REMAINDER)
 
     args = parser.parse_args()
 
-    runner.run(args.input, args.output, args.max_score, args.timeout*60, args.pytest_args)
+    runner.run(args.input, args.output, args.max_score, args.pytest_args)
 
 if __name__ == "__main__":
     main()

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -25,14 +25,15 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-echo "TIMEOUT is $TIMEOUT"
+TIMEOUT=$((TIMEOUT * 60))
+echo "TIMEOUT is $TIMEOUT seconds"
 echo "MAX_SCORE is $MAX_SCORE"
 
-if [ -n "$SETUP_COMMAND" ]; then
-  echo "Running setup command: $SETUP_COMMAND"
-  eval "$SETUP_COMMAND"
+timeout "$TIMEOUT" python3 bin/run.py ./ ./autograding_output/ "$MAX_SCORE"
+exit_status=$?
+if [ $exit_status -eq 124 ]; then
+  echo "The command took longer than $TIMEOUT seconds to execute. Please increase the timeout to avoid this error."
+  echo '{"status": "error", "message": "The command timed out"}' > autograding_output/results.json
 fi
-
-python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE" "$TIMEOUT"
 
 echo "result=$(jq -c . autograding_output/results.json | jq -sRr @base64)" >> "$GITHUB_OUTPUT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts =
-        --color=no
+        --color=yes
 norecursedirs =
         .git .github example* traceback-styles*
 cache_dir =
@@ -9,3 +9,11 @@ markers =
         task: A concept exercise task.
 console_output_style =
         classic
+log_cli = 
+        true  
+log_level =
+        NOTSET  
+log_format = 
+        %(asctime)s %(levelname)s %(message)s  
+log_date_format = 
+        %Y-%m-%d %H:%M:%S

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -198,7 +198,7 @@ def _sanitize_args(args: List[str]) -> List[str]:
     return clean
 
 
-def run(indir: Directory, outdir: Directory, max_score: int, timeout_duration: int, args: List[str]) -> None:
+def run(indir: Directory, outdir: Directory, max_score: int, args: List[str]) -> None:
     """
     Run the tests for the given exercise and produce a results.json.
     """
@@ -214,14 +214,7 @@ def run(indir: Directory, outdir: Directory, max_score: int, timeout_duration: i
     # run the tests and report
     reporter = ResultsReporter()
     reporter.results.max_score = max_score
-    try:
-        @timeout_decorator.timeout(timeout_duration)
-        def run_tests():
-            pytest.main(_sanitize_args(args or []) + [str(tf) for tf in test_files], plugins=[reporter])
-        run_tests()
-    except TimeoutError:
-        reporter.results.error("Tests timed out after {} seconds".format(timeout_duration))
-
+    pytest.main(['-s'] + _sanitize_args(args or []) + [str(tf) for tf in test_files], plugins=[reporter])
     # dump the report
     out_file.write_text(reporter.results.as_json())
     # remove cache directories


### PR DESCRIPTION
Docker environment setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R10): Added `coreutils` to the Docker environment so that it can use timeout.

Pytest configuration:

* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L3-R3): Enabled color in pytest for better readability of test results.
* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R12-R19): Added logging configuration in pytest to provide more detailed information during test execution.

Test runner simplification:

* [`runner/__init__.py`](diffhunk://#diff-ae373fccc1613cb3a222d33ff51e892d58bcdff7173a9e87e80d0d1313b7ac8eL201-R201): Removed the `timeout_duration` parameter from the `run` function to simplify the function signature.
* [`runner/__init__.py`](diffhunk://#diff-ae373fccc1613cb3a222d33ff51e892d58bcdff7173a9e87e80d0d1313b7ac8eL217-R217): Simplified the test execution process by removing the timeout decorator and directly calling `pytest.main` with `[-s]` to capture the logs. 